### PR TITLE
Decorator functions for adding caching and instanceof support to mixing

### DIFF
--- a/mixwith.js
+++ b/mixwith.js
@@ -21,46 +21,73 @@
 
   const _mixinRef = exports._mixinRef = Symbol('_mixinRef');
 
+  const _originalMixin = exports._originalMixin = Symbol('_originalMixin');
+
+  const wrap = exports.wrap = (mixin, wrapper) => {
+    Object.setPrototypeOf(wrapper, mixin);
+    if (!mixin[_originalMixin]) {
+      mixin[_originalMixin] = mixin;
+    }
+    return wrapper;
+  };
+
+  const Cached = exports.Cached = mixin => wrap(mixin, superclass => {
+    // Get or create a symbol used to look up a previous application of mixin
+    // to the class. This symbol is unique per mixin definition, so a class will have N
+    // applicationRefs if it has had N mixins applied to it. A mixin will have
+    // exactly one _cachedApplicationRef used to store its applications.
+    let applicationRef = mixin[_cachedApplicationRef];
+    if (!applicationRef) {
+      applicationRef = mixin[_cachedApplicationRef] = Symbol(mixin.name);
+    }
+    // Look up an existing application of `mixin` to `c`, return it if found.
+    if (superclass.hasOwnProperty(applicationRef)) {
+      return superclass[applicationRef];
+    }
+    // Apply the mixin
+    let application = mixin(superclass);
+    // Cache the mixin application on the superclass
+    superclass[applicationRef] = application;
+    return application;
+  });
+
+  const HasInstance = exports.HasInstance = mixin => {
+    if (Symbol.hasInstance && !mixin.hasOwnProperty(Symbol.hasInstance)) {
+      mixin[Symbol.hasInstance] = function (o) {
+        const originalMixin = this[_originalMixin];
+        while (o != null) {
+          if (o.hasOwnProperty(_mixinRef) && o[_mixinRef] === originalMixin) {
+            return true;
+          }
+          o = Object.getPrototypeOf(o);
+        }
+        return false;
+      };
+    }
+    return mixin;
+  };
+
+  const BareMixin = exports.BareMixin = mixin => wrap(mixin, superclass => {
+    // Apply the mixin
+    let application = mixin(superclass);
+
+    // Attach a reference from mixin applition to wrapped mixin for RTTI
+    // mixin[@@hasInstance] should use this.
+    application.prototype[_mixinRef] = mixin[_originalMixin];
+    return application;
+  });
+
+  const Mixin = exports.Mixin = mixin => Cached(HasInstance(BareMixin(mixin)));
+
   const mix = exports.mix = superClass => new MixinBuilder(superClass);
 
   class MixinBuilder {
     constructor(superclass) {
-      this.superclass = superclass;
+      this.superclass = superclass || Object;
     }
 
     with() {
-      let mixins = Array.prototype.slice.call(arguments);
-      return mixins.reduce((c, mixin) => {
-        let applicationRef = mixin[_cachedApplicationRef];
-
-        if (!applicationRef) {
-          applicationRef = mixin[_cachedApplicationRef] = Symbol(mixin.name);
-        }
-
-        if (c.hasOwnProperty(applicationRef)) {
-          return c[applicationRef];
-        }
-
-        let application = mixin(c);
-        application.prototype[_mixinRef] = mixin;
-        c[applicationRef] = application;
-
-        if (Symbol.hasInstance && !mixin.hasOwnProperty(Symbol.hasInstance)) {
-          mixin[Symbol.hasInstance] = function (o) {
-            do {
-              if (o.hasOwnProperty(_mixinRef) && o[_mixinRef] === this) {
-                return true;
-              }
-
-              o = Object.getPrototypeOf(o);
-            } while (o !== Object);
-
-            return false;
-          };
-        }
-
-        return application;
-      }, this.superclass);
+      return Array.from(arguments).reduce((c, m) => m(c), this.superclass);
     }
 
   }

--- a/src/mixwith.js
+++ b/src/mixwith.js
@@ -2,6 +2,86 @@
 
 export const _cachedApplicationRef = Symbol('_cachedApplicationRef');
 export const _mixinRef = Symbol('_mixinRef');
+export const _originalMixin = Symbol('_originalMixin');
+
+/**
+ * Sets the prototype of mixin to wrapper so that properties set on mixin are
+ * inherited by the wrapper.
+ *
+ * This is needed in order to implement @@hasInstance as a decorator function.
+ */
+export const wrap = (mixin, wrapper) => {
+  Object.setPrototypeOf(wrapper, mixin);
+  if (!mixin[_originalMixin]) {
+    mixin[_originalMixin] = mixin;
+  }
+  return wrapper;
+};
+
+/**
+ * Decorates mixin so that it caches its applications. When applied multiple
+ * times to the same superclass, mixin will only create one subclass and
+ * memoize it.
+ */
+export const Cached = (mixin) => wrap(mixin, (superclass) => {
+  // Get or create a symbol used to look up a previous application of mixin
+  // to the class. This symbol is unique per mixin definition, so a class will have N
+  // applicationRefs if it has had N mixins applied to it. A mixin will have
+  // exactly one _cachedApplicationRef used to store its applications.
+  let applicationRef = mixin[_cachedApplicationRef];
+  if (!applicationRef) {
+    applicationRef = mixin[_cachedApplicationRef] = Symbol(mixin.name);
+  }
+  // Look up an existing application of `mixin` to `c`, return it if found.
+  if (superclass.hasOwnProperty(applicationRef)) {
+    return superclass[applicationRef];
+  }
+  // Apply the mixin
+  let application = mixin(superclass);
+  // Cache the mixin application on the superclass
+  superclass[applicationRef] = application;
+  return application;
+});
+
+/**
+ * Adds @@hasInstance (ES2015 instanceof support) to mixin.
+ * Note: @@hasInstance is not supported in any browsers yet.
+ */
+export const HasInstance = (mixin) => {
+  if (Symbol.hasInstance && !mixin.hasOwnProperty(Symbol.hasInstance)) {
+    mixin[Symbol.hasInstance] = function(o) {
+      const originalMixin = this[_originalMixin];
+      while (o != null) {
+        if (o.hasOwnProperty(_mixinRef) && o[_mixinRef] === originalMixin) {
+          return true;
+        }
+        o = Object.getPrototypeOf(o);
+      }
+      return false;
+    }
+  }
+  return mixin;
+};
+
+/**
+ * A basic mixin decorator that sets up a reference from mixin applications
+ * to the mixin defintion for use by other mixin decorators.
+ */
+export const BareMixin = (mixin) => wrap(mixin, (superclass) => {
+  // Apply the mixin
+  let application = mixin(superclass);
+
+  // Attach a reference from mixin applition to wrapped mixin for RTTI
+  // mixin[@@hasInstance] should use this.
+  application.prototype[_mixinRef] = mixin[_originalMixin];
+  return application;
+});
+
+/**
+ * Decorates a mixin function to add application caching and instanceof
+ * support.
+ */
+export const Mixin = (mixin) => Cached(HasInstance(BareMixin(mixin)));
 
 export const mix = (superClass) => new MixinBuilder(superClass);
 
@@ -12,54 +92,6 @@ class MixinBuilder {
   }
 
   with() {
-    let mixins = Array.prototype.slice.call(arguments);
-    return mixins.reduce((c, mixin) => {
-
-      // Get or create a Symbol used to look up a previous application of mixin
-      // to the class. This symbol is unique per mixin, so a class will have N
-      // applicationRefs if it has had N mixins applied to it. A mixin will have
-      // exactly one _cachedApplicationRef use to store its applications.
-      let applicationRef = mixin[_cachedApplicationRef];
-      if (!applicationRef) {
-        applicationRef = mixin[_cachedApplicationRef] = Symbol(mixin.name);
-      }
-      // Look up an existing application of `mixin` to `c`, return it if found.
-      if (c.hasOwnProperty(applicationRef)) {
-        return c[applicationRef];
-      }
-
-      // Apply the mixin
-      let application = mixin(c);
-
-      // Attach a reference from mixin applition to mixin for RTTI
-      // mixin[@@hasInstance] should use this
-      application.prototype[_mixinRef] = mixin;
-
-      // Cache the mixin application on superclass c
-      c[applicationRef] = application;
-
-      // Patch in instanceof support to mixin
-      // not supported in any browsers yet?
-      if (Symbol.hasInstance && !mixin.hasOwnProperty(Symbol.hasInstance)) {
-        mixin[Symbol.hasInstance] = function(o) {
-          do {
-            if (o.hasOwnProperty(_mixinRef) && o[_mixinRef] === this) {
-              return true;
-            }
-            o = Object.getPrototypeOf(o);
-          } while (o !== Object)
-          return false;
-        }
-      }
-
-      return application;
-    }, this.superclass);
-
+    return Array.from(arguments).reduce((c, m) => m(c), this.superclass);
   }
 }
-
-// function extend(subclass, superclass) {
-//   var prototype = Object.create(superclass.prototype);
-//   prototype.constructor = subclass;
-//   return prototype;
-// }


### PR DESCRIPTION
Addresses #5 by adding BareMixin, Cached, HasInstance and Mixin mixin decorators. `mix().with()` becomes a simple reduce of mixin functions.

This is a potential breaking change for users of `mix().with()` until mixin definitions are updated, but it's probably not very noticiable. `@@hasInstance` isn't supported in any VM yet, so the main change would be that mixin applications are not cached by default.