### PR TITLE
Move babel config from .babelrc to gulp

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "plugins": ["transform-es2015-modules-umd"],
-  "only": [
-    "src/*.js",
-    "test/*.js",
-  ]
-}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,13 @@ gulp.task('default', ['src', 'test']);
 
 gulp.task('src', () =>
     gulp.src('src/mixwith.js')
-        .pipe(babel())
+        .pipe(babel({
+          'plugins': [ 'transform-es2015-modules-umd' ],
+          'only': [
+            'src/*.js',
+            'test/*.js',
+          ]
+        }))
         .pipe(gulp.dest('.'))
         .pipe(gulp.dest('build')));
 


### PR DESCRIPTION
This leaves the configuration of babel up to the gulpfile, rather than the `.babelrc`. This means that it won't conflict if someone is bundling this module using their own, different, babel config.

Fixes #3  