### PR TITLE
Include "module" field for es6 import and rollup/webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "A simple, powerful mixin applier for JavaScript classes",
   "main": "mixwith.js",
+  "module": "src/mixwith.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Fixes https://github.com/justinfagnani/mixwith.js/issues/19